### PR TITLE
Add overriding of GroundingDINO bboxes with calculated masks bboxes

### DIFF
--- a/autodistill_grounded_sam/grounded_sam.py
+++ b/autodistill_grounded_sam/grounded_sam.py
@@ -21,6 +21,8 @@ from segment_anything import SamPredictor
 
 from autodistill.detection import CaptionOntology, DetectionBaseModel
 
+from supervision.detection.utils import mask_to_xyxy
+
 HOME = os.path.expanduser("~")
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -76,6 +78,9 @@ class GroundedSAM(DetectionBaseModel):
             result_masks.append(masks[index])
 
         detections.mask = np.array(result_masks)
+
+        # override GroundingDINO bboxes with calculated masks bboxes
+        detections.xyxy = mask_to_xyxy(detections.mask)
 
         # separate in supervision to combine detections and override class_ids
         return detections


### PR DESCRIPTION
According to the pull request https://github.com/roboflow/supervision/pull/1086

This modification makes it possible to recalculate the bboxes of the masks in order to have a bbox relating to the mask.

Basically, the bbox is the one predicted by autodistill_grounding_dino. Then autodistill_grounded_sam uses this bbox to predict a mask. But the bbox does not correspond directly to the mask.

I therefore use `mask_to_xyxy()` of supervision to recalculate the bboxes relating to the masks.